### PR TITLE
49_[feat]: 성적 등록 페이지 라우팅

### DIFF
--- a/forten/src/components/consultant/chooseSchoolMock.tsx
+++ b/forten/src/components/consultant/chooseSchoolMock.tsx
@@ -1,12 +1,15 @@
-import styled from "styled-components";
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import SchoolTest from '../../pages/consultant/graderegister/schoolTest';
+import MockTest from '../../pages/consultant/graderegister/mockTest';
 
 const Wrapper = styled.div`
   width: 11rem;
   height: 43rem;
-  background-color: #E8E7FF;
+  background-color: #e8e7ff;
   border-top-left-radius: 30px;
   border-bottom-left-radius: 30px;
-`
+`;
 
 const SubBox = styled.div`
   height: 40%;
@@ -14,7 +17,7 @@ const SubBox = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-evenly;
-`
+`;
 
 const StudentName = styled.div`
   width: 80%;
@@ -24,38 +27,36 @@ const StudentName = styled.div`
   align-items: center;
   font-size: 1rem;
   font-weight: 900;
-  background-color: #B59FF2;
+  background-color: #b59ff2;
   border-radius: 30px;
-`
+`;
 
 const SelectTest = styled.div`
-  width: 80%;
+  width: 100%;
   height: 15%;
   display: flex;
   justify-content: center;
   align-items: center;
   font-size: 1rem;
   font-weight: 900;
-  background-color: #D1E1FF;
+  background-color: #d1e1ff;
   border-radius: 30px;
-`
+`;
 
 function ChooseSchoolMock() {
-    return (
-        <Wrapper>
-            <SubBox>
-                <StudentName>
-                    학생명
-                </StudentName>
-                <SelectTest>
-                    내신
-                </SelectTest>
-                <SelectTest>
-                    모의고사
-                </SelectTest>
-            </SubBox>
-        </Wrapper>
-    )
+  return (
+    <Wrapper>
+      <SubBox>
+        <StudentName>학생명</StudentName>
+        <Link to="/MockTest">
+          <SelectTest>내신</SelectTest>
+        </Link>
+        <Link to="/SchoolTest">
+          <SelectTest>모의고사</SelectTest>
+        </Link>
+      </SubBox>
+    </Wrapper>
+  );
 }
 
 export default ChooseSchoolMock;

--- a/forten/src/components/consultant/chooseSchoolMock.tsx
+++ b/forten/src/components/consultant/chooseSchoolMock.tsx
@@ -48,10 +48,10 @@ function ChooseSchoolMock() {
     <Wrapper>
       <SubBox>
         <StudentName>학생명</StudentName>
-        <Link to="/MockTest">
+        <Link to="/SchoolTest">
           <SelectTest>내신</SelectTest>
         </Link>
-        <Link to="/SchoolTest">
+        <Link to="/MockTest">
           <SelectTest>모의고사</SelectTest>
         </Link>
       </SubBox>

--- a/forten/src/components/consultant/studentInfo.tsx
+++ b/forten/src/components/consultant/studentInfo.tsx
@@ -41,10 +41,7 @@ const studentInfo = () => {
           </ImgBox>
 
           <ImgBox>
-            <img src={inquireStudent} alt="학생정보조회하기" />
-          </ImgBox>
-          <ImgBox>
-            <img src={aiPrompt} alt="학생정보조회하기" />
+            <img src={aiPrompt} alt="프롬트제작페이지" />
           </ImgBox>
         </ImgContainer>
         <div>상태</div>

--- a/forten/src/pages/consultant/graderegister/mockTest.tsx
+++ b/forten/src/pages/consultant/graderegister/mockTest.tsx
@@ -1,11 +1,11 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 import NavBar from '../../../components/consultant/navBar';
-import ChooseSchoolMock from "../../../components/consultant/chooseSchoolMock";
-import GradeSelect from "../../../components/consultant/gradeSelect";
-import SubjectLine from "../../../components/consultant/subjectLine";
-import EnterGrades from "../../../components/consultant/enterGrades";
+import ChooseSchoolMock from '../../../components/consultant/chooseSchoolMock';
+import GradeSelect from '../../../components/consultant/gradeSelect';
+import SubjectLine from '../../../components/consultant/subjectLine';
+import EnterGrades from '../../../components/consultant/enterGrades';
 
-// mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨 
+// mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨
 
 const Wrapper = styled.div`
   justify-content: center;
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
   background: linear-gradient(107deg, #fff7f8 7.23%, #e5e4fe 99.24%);
   width: 100%;
   height: 100vh;
-`
+`;
 
 const FlexWrapper = styled.div`
   width: 51rem;
@@ -21,18 +21,18 @@ const FlexWrapper = styled.div`
   background-color: #fff;
   border-radius: 30px;
   display: flex;
-  margin: 2rem auto;'
-`
+  margin: 2rem auto;
+`;
 
 const MainContent = styled.div`
   width: 100%;
-  text-align: center; 
-`
+  text-align: center;
+`;
 
 const Explan = styled.div`
   font-size: 1.5rem;
   margin-top: 2%;
-`
+`;
 
 const FormWrapper = styled.div`
   width: 100%;
@@ -43,7 +43,7 @@ const FormWrapper = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-`
+`;
 
 const EnterGradeWrapper = styled.div`
   width: 100%;
@@ -52,46 +52,46 @@ const EnterGradeWrapper = styled.div`
   top: 0;
   display: flex;
   justify-content: space-evenly;
-`
+`;
 
 function MockTest() {
-    return (
-        // 중앙에 위치할 수 있도록 큰 div로 묶기
-        <Wrapper>
-            <NavBar />
-            <FlexWrapper>
-                <ChooseSchoolMock />
-                <MainContent>
-                    <Explan>모의고사 등급을 입력해주세요</Explan>
-                    <GradeSelect />
-                    <FormWrapper>
-                        <SubjectLine />
-                        <EnterGradeWrapper>
-                            {/* 
-                            * 여기 아래의 성적 입력 컴포넌트들을
-                             * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
-                          */}
-                            <EnterGrades />
-                            <EnterGrades />
-                            <EnterGrades />
-                        </EnterGradeWrapper>
-                    </FormWrapper>
-                    <FormWrapper>
-                        <SubjectLine />
-                        <EnterGradeWrapper>
-                            {/* 
-                            * 여기 아래의 성적 입력 컴포넌트들을
-                             * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
-                          */}
-                            <EnterGrades />
-                            <EnterGrades />
-                            <EnterGrades />
-                        </EnterGradeWrapper>
-                    </FormWrapper>
-                </MainContent>
-            </FlexWrapper>
-        </Wrapper>
-    )
+  return (
+    // 중앙에 위치할 수 있도록 큰 div로 묶기
+    <Wrapper>
+      <NavBar />
+      <FlexWrapper>
+        <ChooseSchoolMock />
+        <MainContent>
+          <Explan>모의고사 등급을 입력해주세요</Explan>
+          <GradeSelect />
+          <FormWrapper>
+            <SubjectLine />
+            <EnterGradeWrapper>
+              {/*
+               * 여기 아래의 성적 입력 컴포넌트들을
+               * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
+               */}
+              <EnterGrades />
+              <EnterGrades />
+              <EnterGrades />
+            </EnterGradeWrapper>
+          </FormWrapper>
+          <FormWrapper>
+            <SubjectLine />
+            <EnterGradeWrapper>
+              {/*
+               * 여기 아래의 성적 입력 컴포넌트들을
+               * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
+               */}
+              <EnterGrades />
+              <EnterGrades />
+              <EnterGrades />
+            </EnterGradeWrapper>
+          </FormWrapper>
+        </MainContent>
+      </FlexWrapper>
+    </Wrapper>
+  );
 }
 
 export default MockTest;

--- a/forten/src/pages/consultant/graderegister/schoolTest.tsx
+++ b/forten/src/pages/consultant/graderegister/schoolTest.tsx
@@ -1,40 +1,40 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 import NavBar from '../../../components/consultant/navBar';
-import ChooseSchoolMock from "../../../components/consultant/chooseSchoolMock";
-import GradeSelect from "../../../components/consultant/gradeSelect";
-import SubjectLine from "../../../components/consultant/subjectLine";
-import EnterGrades from "../../../components/consultant/enterGrades";
+import ChooseSchoolMock from '../../../components/consultant/chooseSchoolMock';
+import GradeSelect from '../../../components/consultant/gradeSelect';
+import SubjectLine from '../../../components/consultant/subjectLine';
+import EnterGrades from '../../../components/consultant/enterGrades';
 
-// mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨 
+// mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨
 
-const Wrapper = styled.div`
+export const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   background: linear-gradient(107deg, #fff7f8 7.23%, #e5e4fe 99.24%);
   width: 100%;
   height: 100vh;
-`
+`;
 
-const FlexWrapper = styled.div`
+export const FlexWrapper = styled.div`
   width: 51rem;
   height: 43rem;
   background-color: #fff;
   border-radius: 30px;
   display: flex;
-  margin: 2rem auto;'
-`
+  margin: 2rem auto;
+`;
 
-const MainContent = styled.div`
+export const MainContent = styled.div`
   width: 100%;
-  text-align: center; 
-`
+  text-align: center;
+`;
 
-const Explan = styled.div`
+export const Explan = styled.div`
   font-size: 1.5rem;
   margin-top: 2%;
-`
+`;
 
-const FormWrapper = styled.div`
+export const FormWrapper = styled.div`
   width: 100%;
   height: 15.25rem;
   margin-top: 15%;
@@ -43,20 +43,21 @@ const FormWrapper = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-`
+`;
 
-const EnterGradeWrapper = styled.div`
+export const EnterGradeWrapper = styled.div`
   width: 100%;
   padding-left: 15%;
   position: absolute;
   top: 0;
   display: flex;
   justify-content: space-evenly;
-`
+`;
 
 function SchoolTest() {
   return (
     // 중앙에 위치할 수 있도록 큰 div로 묶기
+
     <Wrapper>
       <NavBar />
       <FlexWrapper>
@@ -67,9 +68,9 @@ function SchoolTest() {
           <FormWrapper>
             <SubjectLine />
             <EnterGradeWrapper>
-              {/* 
-                * 여기 아래의 성적 입력 컴포넌트들을
-                * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
+              {/*
+               * 여기 아래의 성적 입력 컴포넌트들을
+               * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
                */}
               <EnterGrades />
               <EnterGrades />
@@ -80,7 +81,7 @@ function SchoolTest() {
         </MainContent>
       </FlexWrapper>
     </Wrapper>
-  )
+  );
 }
 
 export default SchoolTest;

--- a/forten/src/router.tsx
+++ b/forten/src/router.tsx
@@ -20,6 +20,9 @@ import Evaluationstudent from './pages/teacher/evaluationstudent/index';
 import OnBoardingPage from './pages/onboard/thirdpage/index';
 
 import AiPromptPage from './pages/consultant/AiPrompt';
+import MockGrade from './pages/consultant/graderegister/mockTest';
+import SchoolGrade from './pages/consultant/graderegister/schoolTest';
+
 const routers = createBrowserRouter([
   {
     path: '/',
@@ -56,6 +59,15 @@ const routers = createBrowserRouter([
   {
     path: '/consultantMain',
     element: <ConsultantMainPage />,
+  },
+  {
+    path: '/schooltest',
+    element: <SchoolGrade />,
+  },
+
+  {
+    path: '/mocktest',
+    element: <MockGrade />,
   },
   {
     path: '/aiprompt',


### PR DESCRIPTION
## 📖 개요
- PR 네이밍은 이슈번호_이슈제목

성적등록 페이지에서 내신을 누르면 내신 성적 입력 표가, 모의고사를 누르면 모의고사 성적 입력 표가 나옵니다. 
내신, 모의고사를 누를때마다 위에 로고가 새로고침 되듯이 딜레이시간이 있어 제 로컬에서의 문제인지 확인하려 합니다.
![스크린샷 2024-01-16 오후 11 32 59](https://github.com/Techeer-H/frontend/assets/74411978/83273b31-4345-4ca2-8a05-300ac0ec0c29)


## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list
- [x] merge 브랜치 확인했나요?
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
