### PR TITLE
69_[feat]: 컨설턴트 메인에서 다른 페이지로 학생 id넘기기

### DIFF
--- a/forten/src/components/consultant/chooseSchoolMock.tsx
+++ b/forten/src/components/consultant/chooseSchoolMock.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const Wrapper = styled.div`
   width: 11rem;
@@ -41,17 +41,30 @@ const SelectTest = styled.div`
   border-radius: 30px;
 `;
 
-function ChooseSchoolMock() {
+interface studentId {
+  studentId: string
+}
+
+function ChooseSchoolMock({ studentId }: studentId) {
+  const navigate = useNavigate();
+
+
+  console.log('내신, 모의고사 선택 컴포넌트', studentId);
+
+  const moveSchoolTestHandler = () => {
+    navigate('/schooltest', { state: { studentId } });
+  };
+
+  const moveMockTestHandler = () => {
+    navigate('/mocktest', { state: { studentId } });
+  };
+
   return (
     <Wrapper>
       <SubBox>
         <StudentName>학생명</StudentName>
-        <Link to="/SchoolTest">
-          <SelectTest>내신</SelectTest>
-        </Link>
-        <Link to="/MockTest">
-          <SelectTest>모의고사</SelectTest>
-        </Link>
+        <SelectTest onClick={moveSchoolTestHandler}>내신</SelectTest>
+        <SelectTest onClick={moveMockTestHandler}>모의고사</SelectTest>
       </SubBox>
     </Wrapper>
   );

--- a/forten/src/components/consultant/enterGrades.tsx
+++ b/forten/src/components/consultant/enterGrades.tsx
@@ -7,13 +7,19 @@ import axios from 'axios';
 interface EnterGradesProps {
   examId: string;
   selectedGrade: string;
+  studentId: number;
 }
 
-function EnterGrades({ examId, selectedGrade }: EnterGradesProps) {
+function EnterGrades({ examId, selectedGrade, studentId }: EnterGradesProps) {
   // 각 과목에 대한 등급을 상태로 관리(값이 학년, 학기별로 변하므로)
   const [koreanGrade, setKoreanGrade] = useState('');
   const [mathGrade, setMathGrade] = useState('');
   const [englishGrade, setEnglishGrade] = useState('');
+
+  // 학생 id를 받아옴, 이 student 값을 통신할 때 보내면
+  // 해당 학생에 대한 성적을 입력할 수 있음
+  const student = studentId
+  console.log(student);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     // 폼 제출할 때 실행되는 함수-등급을 서버에 저장하는 로직 ㅇ

--- a/forten/src/components/consultant/studentInfo.tsx
+++ b/forten/src/components/consultant/studentInfo.tsx
@@ -1,11 +1,12 @@
 // 학생리스트
-
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import aiPrompt from '../../assets/AIPrompt.svg';
 import registerGrade from '../../assets/registerGrade.svg';
 import axios from 'axios';
 import RedStatusButton from './redStatusButton';
+import GreenStatusButton from './greenStatusButton';
 
 //1차 샘플데이터
 // const studentInfo = () => {
@@ -40,33 +41,38 @@ interface Student {
   birth: string;
   phone: string;
   parent_phone: string;
+  isFeedback: boolean;
 }
 
 interface Props {
   studentInput: string;
+  selectedStatus: string
 }
+const user_Id = localStorage.getItem('user_Id');
 
-const StudentInfo = ({ studentInput }: Props) => {
+const StudentInfo = ({ studentInput, selectedStatus }: Props) => {
   const [studentlist, setStudentList] = useState<Student[]>([]);
+  const navigate = useNavigate();
 
   const getStudentList = async () => {
     let response;
 
-    const user_id = localStorage.getItem('user_id');
+
+    console.log(user_Id);
 
     if (studentInput === '') {
-      response = await axios.get(`http://3.37.41.244:8000/api/student/?id=${user_id}`);
+      response = await axios.get(`http://3.37.41.244:8000/api/student/?id=${user_Id}`);
     } else {
       if (isNaN(Number(studentInput))) {
         // 숫자가 아닐때가
         console.log(studentInput);
         response = await axios.get(
-          `http://3.37.41.244:8000/api/student/?id=${user_id}&search=${studentInput}`,
+          `http://3.37.41.244:8000/api/student/?id=${user_Id}&search=${studentInput}`,
         );
       } else {
         // 숫자일때
         response = await axios.get(
-          `http://3.37.41.244:8000/api/student/?id=${user_id}&student_id=${studentInput}`,
+          `http://3.37.41.244:8000/api/student/?id=${user_Id}&student_id=${studentInput}`,
         );
       }
       setStudentList(response.data.result); //여기까지하면 처음페이지 불러올떄 있는 목록만 나옴
@@ -79,29 +85,49 @@ const StudentInfo = ({ studentInput }: Props) => {
     getStudentList();
   }, [studentInput]);
 
+  const gradeRegisterHandler = (studentId: number) => {
+    navigate('/schooltest', { state: { studentId } })
+  }
+
+  const aiPromptHandler = (studentId: number) => {
+    navigate('/aiprompt', { state: { studentId } })
+  }
+
   return (
     <Wrapper>
       <Ul>
-        {studentlist.map((student) => (
-          <Li key={student.id}>
-            <Text>{student.name}</Text>
-            <Text>{student.school}</Text>
-            <Text>{student.birth}</Text>
-            <Text>{student.phone}</Text>
-            <Text>{student.parent_phone}</Text>
-            <ImgContainer>
-              <ImgBox>
-                <img src={registerGrade} alt="성적등록하기" />
-              </ImgBox>
-              <ImgBox2>
-                <img src={aiPrompt} alt="프롬트제작페이지" />
-              </ImgBox2>
-            </ImgContainer>
+        {studentlist.map((student) => {
+          if (
+            (selectedStatus === '1' && (student.isFeedback || !student.isFeedback)) ||
+            (selectedStatus === '2' && student.isFeedback) ||
+            (selectedStatus === '3' && !student.isFeedback)
+          ) {
+            return (
+              <Li key={student.id}>
+                <Text>{student.name}</Text>
+                <Text>{student.school}</Text>
+                <Text>{student.birth}</Text>
+                <Text>{student.phone}</Text>
+                <Text>{student.parent_phone}</Text>
+                <ImgContainer>
+                  <ImgBox onClick={() => gradeRegisterHandler(student.id)}>
+                    <img src={registerGrade} alt="성적등록하기" />
+                  </ImgBox>
+                  <ImgBox2 onClick={() => aiPromptHandler(student.id)}>
+                    <img src={aiPrompt} alt="프롬트제작페이지" />
+                  </ImgBox2>
+                </ImgContainer>
 
-            {/* <GreenStatusButton /> */}
-            <RedStatusButton />
-          </Li>
-        ))}
+                {/* 평가 여부에 따른 상태 (완료, 미완료) 나타내기 */}
+                {selectedStatus === '1' && (student.isFeedback ? <GreenStatusButton /> : <RedStatusButton />)}
+                {selectedStatus === '2' && student.isFeedback && <GreenStatusButton />}
+                {selectedStatus === '3' && !student.isFeedback && <RedStatusButton />}
+              </Li>
+            );
+          }
+          // 해당 조건에 맞지 않으면 null을 반환하여 렌더링되지 않도록 함
+          return null;
+        })}
       </Ul>
     </Wrapper>
   );

--- a/forten/src/pages/consultant/AiPrompt/index.tsx
+++ b/forten/src/pages/consultant/AiPrompt/index.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import Navbar from '../../../components/consultant/navBar';
 import * as S from './styles';
 import StudentTable from '../../../components/modal/studentTable';
@@ -13,6 +14,11 @@ import { useState } from 'react';
 // const FlexWrapper = styled.div``;
 
 const AiPromptPage = () => {
+  const location = useLocation();
+
+  // 학생 아이디 가져오기 성공
+  // 통신하는 자식 컴포넌트에게 props 값을 넘겨주면 됨.
+  console.log('ai 프롬트 학생 아이디 가져오기', location.state.studentId);
 
   // 상담 완료 후 모달 껐다 켰다 하는 부분, 모달은 ConsultantRatingPage임
   const [isModal, setIsModal] = useState(false);

--- a/forten/src/pages/consultant/consultantmain/index.tsx
+++ b/forten/src/pages/consultant/consultantmain/index.tsx
@@ -24,6 +24,7 @@ export type UserType = {
 const ConsultantMainPage = () => {
   const [isModalOpened, setIsOpened] = useState<boolean>(false);
   const [studentInput, setStudentInput] = useState<string>('');
+  const [stateSelect, setStateSelect] = useState('1');
 
   // const [userData, setUserData] = useState<UserType>({
   //   user_id: '',
@@ -70,9 +71,9 @@ const ConsultantMainPage = () => {
   // }, []);
 
   useEffect(() => {
-    const user_id = localStorage.getItem('user_id');
+    const user_Id = localStorage.getItem('user_Id');
     axios
-      .get(`http://3.37.41.244:8000/api/student/?id=${user_id}/`)
+      .get(`http://3.37.41.244:8000/api/student/?id=${user_Id}/`)
       .then((response) => {
         // 로그인 성공 시 처리
         const userData: { result: UserType } = response.data.id;
@@ -85,6 +86,13 @@ const ConsultantMainPage = () => {
         // 예: 에러 메시지 표시 등
       });
   }, []);
+
+  const stateSelectHandler = (event) => {
+    const selectOption = event.target.value;
+    setStateSelect(selectOption);
+  };
+
+  console.log(stateSelect);
 
   return (
     // 전체화면
@@ -128,8 +136,7 @@ const ConsultantMainPage = () => {
               </S.StudentSearchContainer>
 
               <S.DropDownContainer>
-                <S.StyledSelect className="text-gray-700">
-                  <option>선택 </option>
+                <S.StyledSelect className="text-gray-700" onChange={stateSelectHandler} value={stateSelect}>
                   <option value="1">전체</option>
                   <option value="2">완료</option>
                   <option value="3">미완료</option>
@@ -140,7 +147,7 @@ const ConsultantMainPage = () => {
             <GrayBox />
             {/*  ConsultantMainPage 컴포넌트에서 StudentInfo 컴포넌트 사용 부분
  StudentInfo 컴포넌트에 studentlist를 props로 전달하고, 검색 결과에 따라 이를 업데이트할 수 있도록 함 */}
-            <StudentInfo studentInput={studentInput} />
+            <StudentInfo studentInput={studentInput} selectedStatus={stateSelect} />
           </S.SearchContainer>
 
           <Memo />

--- a/forten/src/pages/consultant/graderegister/mockTest.tsx
+++ b/forten/src/pages/consultant/graderegister/mockTest.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import NavBar from '../../../components/consultant/navBar';
 import ChooseSchoolMock from '../../../components/consultant/chooseSchoolMock';
@@ -9,13 +10,17 @@ import { useState } from 'react';
 // mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨
 
 function MockTest() {
+  // 메인 페이지에서 학생 id가져오기
+  const location = useLocation();
+  console.log('모의고사 점수 등록 페이지. 학생 아이디는 다음과 같다.', location.state.studentId);
+
   const [selectedGrade, setSelectedGrade] = useState('');
 
   return (
     <Wrapper>
       <NavBar />
       <FlexWrapper>
-        <ChooseSchoolMock />
+        <ChooseSchoolMock studentId={location.state.studentId} />
         <MainContent>
           <Explan>모의고사 등급을 입력해주세요</Explan>
           <GradeSelect selectedGrade={selectedGrade} setSelectedGrade={setSelectedGrade} />
@@ -26,9 +31,9 @@ function MockTest() {
                * 여기 아래의 성적 입력 컴포넌트들을
                * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
                */}
-              <EnterGrades examId="5" selectedGrade={selectedGrade} />
-              <EnterGrades examId="6" selectedGrade={selectedGrade} />
-              <EnterGrades examId="7" selectedGrade={selectedGrade} />
+              <EnterGrades examId="5" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="6" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="7" selectedGrade={selectedGrade} studentId={location.state.studentId} />
             </EnterGradeWrapper>
           </FormWrapper>
           <FormWrapper>
@@ -38,9 +43,9 @@ function MockTest() {
                * 여기 아래의 성적 입력 컴포넌트들을
                * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
                */}
-              <EnterGrades examId="8" selectedGrade={selectedGrade} />
-              <EnterGrades examId="9" selectedGrade={selectedGrade} />
-              <EnterGrades examId="10" selectedGrade={selectedGrade} />
+              <EnterGrades examId="8" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="9" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="10" selectedGrade={selectedGrade} studentId={location.state.studentId} />
             </EnterGradeWrapper>
           </FormWrapper>
         </MainContent>

--- a/forten/src/pages/consultant/graderegister/schoolTest.tsx
+++ b/forten/src/pages/consultant/graderegister/schoolTest.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import NavBar from '../../../components/consultant/navBar';
 import ChooseSchoolMock from '../../../components/consultant/chooseSchoolMock';
@@ -11,16 +12,20 @@ import { useState } from 'react';
 // mocktest와 schooltest를 어떻게 라우터화 할 지 고민해봐야됨
 
 function SchoolTest() {
+  // 메인 페이지에서 학생 id가져오기
+  const location = useLocation();
+
   // 상태를 추가하고 해당 상태의 값을 가져오거나 업테이트
   //이게 setState인가?? 암튼 setState을
   //최종값 업데이트하는 값
   const [selectedGrade, setSelectedGrade] = useState('고1');
 
+  console.log('내신 등급 입력 컴포넌트', location.state.studentId);
   return (
     <Wrapper>
       <NavBar />
       <FlexWrapper>
-        <ChooseSchoolMock />
+        <ChooseSchoolMock studentId={location.state.studentId} />
         <MainContent>
           <Explan>내신 등급을 입력해주세요</Explan>
           <GradeSelect selectedGrade={selectedGrade} setSelectedGrade={setSelectedGrade} />
@@ -31,10 +36,10 @@ function SchoolTest() {
                * 여기 아래의 성적 입력 컴포넌트들을
                * props를 사용하여 구분하면 되지 않을까 하는 생각입니다
                */}
-              <EnterGrades examId="1" selectedGrade={selectedGrade} />
-              <EnterGrades examId="2" selectedGrade={selectedGrade} />
-              <EnterGrades examId="3" selectedGrade={selectedGrade} />
-              <EnterGrades examId="4" selectedGrade={selectedGrade} />
+              <EnterGrades examId="1" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="2" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="3" selectedGrade={selectedGrade} studentId={location.state.studentId} />
+              <EnterGrades examId="4" selectedGrade={selectedGrade} studentId={location.state.studentId} />
             </EnterGradeWrapper>
           </FormWrapper>
         </MainContent>


### PR DESCRIPTION
## 📖 개요
- PR 네이밍은 이슈번호_이슈제목

## 💻 작업사항[브라우저 페이지 화면 사진 첨부]
- 컨설턴트 메인 페이지: 로컬 스토리지에서 로그인 한 id를 가져왔습니다.
- 성적 등록 페이지와 ai 요약 페이지로 학생 id를 넘기는 작업을 했습니다.


## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list
- [ ] merge 브랜치 확인했나요?
- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
